### PR TITLE
Feature/cs/cataloging tests

### DIFF
--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -518,7 +518,7 @@ class OsidSession:
             else:
                 uses_cataloging = True
                 lookup_session = cataloging_manager.get_catalog_lookup_session()
-                self._my_catalog_map = lookup_session.get_catalog(self._catalog_identifier)._my_map
+                self._my_catalog_map = lookup_session.get_catalog(catalog_id)._my_map
                 self._catalog = Catalog(osid_object_map=self._my_catalog_map, runtime=self._runtime,
                                         proxy=self._proxy)
         else:

--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -525,6 +525,9 @@ class OsidSession:
             self._catalog_identifier = PHANTOM_ROOT_IDENTIFIER
             self._my_catalog_map = make_catalog_map(cat_name, identifier=self._catalog_identifier)
 
+        # The reason to add in this flag is because Catalogs are not Extensible, which means they
+        #   do not have a ``recordTypeIds`` field. This means when you try to initialize ``cat_class``
+        #   with a map from a Catalog, the Extensible method ``_init_records`` throws a KeyError.
         if not uses_cataloging:
             self._catalog = cat_class(osid_object_map=self._my_catalog_map, runtime=self._runtime, proxy=self._proxy)
 

--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -502,8 +502,8 @@ class OsidSession:
                 config = self._runtime.get_configuration()
                 parameter_id = Id('parameter:' + db_name + 'CatalogingProviderImpl@mongo')
                 provider_impl = config.get_value_by_parameter(parameter_id).get_string_value()
-                self._cataloging_manager = self._runtime.get_manager('CATALOGING',
-                                                                     provider_impl)  # need to add version argument
+                cataloging_manager = self._runtime.get_manager('CATALOGING',
+                                                                provider_impl)  # need to add version argument
             except (AttributeError, KeyError, errors.NotFound):
                 try:
                     collection = JSONClientValidated(db_name,
@@ -517,10 +517,8 @@ class OsidSession:
                         raise errors.NotFound('could not find catalog identifier ' + catalog_id.get_identifier() + cat_name)
             else:
                 uses_cataloging = True
-                collection = JSONClientValidated('cataloging',
-                                                 collection='Catalog',
-                                                 runtime=self._runtime)
-                self._my_catalog_map = collection.find_one({'_id': ObjectId(self._catalog_identifier)})
+                lookup_session = cataloging_manager.get_catalog_lookup_session()
+                self._my_catalog_map = lookup_session.get_catalog(self._catalog_identifier)._my_map
                 self._catalog = Catalog(osid_object_map=self._my_catalog_map, runtime=self._runtime,
                                         proxy=self._proxy)
         else:

--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -498,17 +498,16 @@ class OsidSession:
         if catalog_id is not None and catalog_id.get_identifier() != PHANTOM_ROOT_IDENTIFIER:
             self._catalog_identifier = catalog_id.get_identifier()
 
+            config = self._runtime.get_configuration()
+            parameter_id = Id('parameter:' + db_name + 'CatalogingProviderImpl@mongo')
+
             try:
-                config = self._runtime.get_configuration()
-                parameter_id = Id('parameter:' + db_name + 'CatalogingProviderImpl@mongo')
                 provider_impl = config.get_value_by_parameter(parameter_id).get_string_value()
-                cataloging_manager = self._runtime.get_manager('CATALOGING',
-                                                               provider_impl)  # need to add version argument
             except (AttributeError, KeyError, errors.NotFound):
+                collection = JSONClientValidated(db_name,
+                                                 collection=cat_name,
+                                                 runtime=self._runtime)
                 try:
-                    collection = JSONClientValidated(db_name,
-                                                     collection=cat_name,
-                                                     runtime=self._runtime)
                     self._my_catalog_map = collection.find_one({'_id': ObjectId(self._catalog_identifier)})
                 except errors.NotFound:
                     if catalog_id.get_identifier_namespace() != db_name + '.' + cat_name:
@@ -517,6 +516,8 @@ class OsidSession:
                         raise errors.NotFound('could not find catalog identifier ' + catalog_id.get_identifier() + cat_name)
             else:
                 uses_cataloging = True
+                cataloging_manager = self._runtime.get_manager('CATALOGING',
+                                                               provider_impl)  # need to add version argument
                 lookup_session = cataloging_manager.get_catalog_lookup_session()
                 self._my_catalog_map = lookup_session.get_catalog(catalog_id)._my_map
                 self._catalog = Catalog(osid_object_map=self._my_catalog_map, runtime=self._runtime,
@@ -525,9 +526,6 @@ class OsidSession:
             self._catalog_identifier = PHANTOM_ROOT_IDENTIFIER
             self._my_catalog_map = make_catalog_map(cat_name, identifier=self._catalog_identifier)
 
-        # The reason to add in this flag is because Catalogs are not Extensible, which means they
-        #   do not have a ``recordTypeIds`` field. This means when you try to initialize ``cat_class``
-        #   with a map from a Catalog, the Extensible method ``_init_records`` throws a KeyError.
         if not uses_cataloging:
             self._catalog = cat_class(osid_object_map=self._my_catalog_map, runtime=self._runtime, proxy=self._proxy)
 

--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -503,7 +503,7 @@ class OsidSession:
                 parameter_id = Id('parameter:' + db_name + 'CatalogingProviderImpl@mongo')
                 provider_impl = config.get_value_by_parameter(parameter_id).get_string_value()
                 cataloging_manager = self._runtime.get_manager('CATALOGING',
-                                                                provider_impl)  # need to add version argument
+                                                               provider_impl)  # need to add version argument
             except (AttributeError, KeyError, errors.NotFound):
                 try:
                     collection = JSONClientValidated(db_name,

--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -438,6 +438,7 @@ class OsidSession:
         'from ..utilities import get_locale_with_proxy',
         'from ..utilities import make_catalog_map',
         'from ..utilities import camel_to_under',
+        'from ..cataloging.objects import Catalog',
         'from .. import types',
         'COMPARATIVE = 0',
         'PLENARY = 1',
@@ -493,23 +494,39 @@ class OsidSession:
         self._catalog_identifier = None
         self._init_proxy_and_runtime(proxy, runtime)
 
+        uses_cataloging = False
         if catalog_id is not None and catalog_id.get_identifier() != PHANTOM_ROOT_IDENTIFIER:
             self._catalog_identifier = catalog_id.get_identifier()
 
-            collection = JSONClientValidated(db_name,
-                                             collection=cat_name,
-                                             runtime=self._runtime)
             try:
+                # Try cataloging first? It seems there is no way to check the runtime config here,
+                #   since in testing, this appears to already be the "CatalogingProviderImpl" config
+                collection = JSONClientValidated('cataloging',
+                                                 collection='Catalog',
+                                                 runtime=self._runtime)
                 self._my_catalog_map = collection.find_one({'_id': ObjectId(self._catalog_identifier)})
             except errors.NotFound:
-                if catalog_id.get_identifier_namespace() != db_name + '.' + cat_name:
-                    self._my_catalog_map = self._create_orchestrated_cat(catalog_id, db_name, cat_name)
-                else:
-                    raise errors.NotFound('could not find catalog identifier ' + catalog_id.get_identifier() + cat_name)
+                try:
+                    collection = JSONClientValidated(db_name,
+                                                     collection=cat_name,
+                                                     runtime=self._runtime)
+                    self._my_catalog_map = collection.find_one({'_id': ObjectId(self._catalog_identifier)})
+                except errors.NotFound:
+                    if catalog_id.get_identifier_namespace() != db_name + '.' + cat_name:
+                        self._my_catalog_map = self._create_orchestrated_cat(catalog_id, db_name, cat_name)
+                    else:
+                        raise errors.NotFound('could not find catalog identifier ' + catalog_id.get_identifier() + cat_name)
+            else:
+                uses_cataloging = True
+                self._catalog = Catalog(osid_object_map=self._my_catalog_map, runtime=self._runtime,
+                                        proxy=self._proxy)
         else:
             self._catalog_identifier = PHANTOM_ROOT_IDENTIFIER
             self._my_catalog_map = make_catalog_map(cat_name, identifier=self._catalog_identifier)
-        self._catalog = cat_class(osid_object_map=self._my_catalog_map, runtime=self._runtime, proxy=self._proxy)
+
+        if not uses_cataloging:
+            self._catalog = cat_class(osid_object_map=self._my_catalog_map, runtime=self._runtime, proxy=self._proxy)
+
         self._catalog._authority = self._authority  # there should be a better way...
         self._catalog_id = self._catalog.get_id()
         self._forms = dict()

--- a/test_templates/assessment.py
+++ b/test_templates/assessment.py
@@ -3666,7 +3666,9 @@ class BankQuery:
 
 class BankForm:
     get_bank_form_record = """
-        if not is_never_authz(self.service_config):
+        if uses_cataloging(self.service_config):
+            pass  # cannot call the _get_record() methods on catalogs
+        elif not is_never_authz(self.service_config):
             with pytest.raises(errors.Unsupported):
                 self.object.get_bank_form_record(DEFAULT_TYPE)"""
 

--- a/test_templates/resource.py
+++ b/test_templates/resource.py
@@ -2602,7 +2602,7 @@ def ${interface_name_under}_test_fixture(request):
 class BinNode:
 
     import_statements_pattern = [
-        'from dlkit.abstract_osid.cataloging.objects import Catalog'
+        'from dlkit.abstract_osid.osid.objects import OsidCatalog'
     ]
 
     init_template = """
@@ -2669,10 +2669,7 @@ def ${interface_name_under}_test_fixture(request):
         # from test_templates/resource.py::BinNode::get_bin_template
         from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${cat_name}
         if not is_never_authz(self.service_config):
-            if uses_cataloging(self.service_config):
-                assert isinstance(self.${cat_name_under}_list[0].${method_name}(), Catalog)
-            else:
-                assert isinstance(self.${cat_name_under}_list[0].${method_name}(), ${cat_name})
+            assert isinstance(self.${cat_name_under}_list[0].${method_name}(), OsidCatalog)
             assert str(self.${cat_name_under}_list[0].${method_name}().ident) == str(self.${cat_name_under}_list[0].ident)"""
 
     get_parent_bin_nodes_template = """

--- a/test_templates/resource.py
+++ b/test_templates/resource.py
@@ -1416,6 +1416,7 @@ def ${interface_name_under}_test_fixture(request):
 class BinAdminSession:
 
     import_statements_pattern = [
+        'from dlkit.abstract_osid.osid.objects import OsidCatalogForm, OsidCatalog',
         'from dlkit.runtime import PROXY_SESSION, proxy_example',
         'from dlkit.runtime.managers import Runtime',
         'from dlkit.primordium.id.primitives import Id',
@@ -1486,7 +1487,7 @@ def ${interface_name_under}_test_fixture(request):
         from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${return_type}
         if not is_never_authz(self.service_config):
             catalog_form = self.svc_mgr.${method_name}([])
-            assert isinstance(catalog_form, ${return_type})
+            assert isinstance(catalog_form, OsidCatalogForm)
             assert not catalog_form.is_for_update()
         else:
             with pytest.raises(errors.PermissionDenied):
@@ -1500,7 +1501,7 @@ def ${interface_name_under}_test_fixture(request):
             catalog_form.display_name = 'Test ${cat_name}'
             catalog_form.description = 'Test ${cat_name} for ${interface_name}.${method_name} tests'
             new_catalog = self.svc_mgr.${method_name}(catalog_form)
-            assert isinstance(new_catalog, ${return_type})
+            assert isinstance(new_catalog, OsidCatalog)
         else:
             with pytest.raises(errors.PermissionDenied):
                 self.svc_mgr.${method_name}('foo')"""
@@ -1510,7 +1511,7 @@ def ${interface_name_under}_test_fixture(request):
         from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${return_type}
         if not is_never_authz(self.service_config):
             catalog_form = self.svc_mgr.${method_name}(self.catalog.ident)
-            assert isinstance(catalog_form, ${return_type})
+            assert isinstance(catalog_form, OsidCatalogForm)
             assert catalog_form.is_for_update()
         else:
             with pytest.raises(errors.PermissionDenied):
@@ -1553,6 +1554,7 @@ def ${interface_name_under}_test_fixture(request):
 class BinHierarchySession:
 
     import_statements_pattern = [
+        'from dlkit.abstract_osid.osid.objects import OsidList',
         'from dlkit.abstract_osid.id.objects import IdList',
         'from dlkit.abstract_osid.hierarchy.objects import Hierarchy',
         'from dlkit.abstract_osid.osid.objects import OsidNode',
@@ -1633,7 +1635,7 @@ def ${interface_name_under}_test_fixture(request):
         from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${cat_name}List
         if not is_never_authz(self.service_config):
             roots = self.svc_mgr.${method_name}()
-            assert isinstance(roots, ${cat_name}List)
+            assert isinstance(roots, OsidList)
             assert roots.available() == 1
         else:
             with pytest.raises(errors.PermissionDenied):
@@ -1675,10 +1677,9 @@ def ${interface_name_under}_test_fixture(request):
 
     get_parent_bins_template = """
         # From test_templates/resource.py::BinHierarchySession::get_parent_bins_template
-        from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${return_type}
         if not is_never_authz(self.service_config):
             catalog_list = self.svc_mgr.${method_name}(self.catalogs['Child 1'].ident)
-            assert isinstance(catalog_list, ${return_type})
+            assert isinstance(catalog_list, OsidList)
             assert catalog_list.available() == 1
             assert catalog_list.next().display_name.text == 'Root'
         else:
@@ -1745,10 +1746,9 @@ def ${interface_name_under}_test_fixture(request):
 
     get_child_bins_template = """
         # From test_templates/resource.py::BinHierarchySession::get_child_bins_template
-        from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${return_type}
         if not is_never_authz(self.service_config):
             catalog_list = self.svc_mgr.${method_name}(self.catalogs['Child 1'].ident)
-            assert isinstance(catalog_list, ${return_type})
+            assert isinstance(catalog_list, OsidList)
             assert catalog_list.available() == 1
             assert catalog_list.next().display_name.text == 'Grandchild 1'
         else:
@@ -1865,7 +1865,7 @@ def ${interface_name_under}_test_fixture(request):
         # this is tested in the setUpClass
         if not is_never_authz(self.service_config):
             roots = self.session.get_root_${cat_name_plural_under}()
-            assert isinstance(roots, ABCObjects.${cat_name}List)
+            assert isinstance(roots, OsidList)
             assert roots.available() == 1
         else:
             with pytest.raises(errors.PermissionDenied):
@@ -1899,7 +1899,7 @@ def ${interface_name_under}_test_fixture(request):
         if not is_never_authz(self.service_config):
             # this is tested in the setUpClass
             children = self.session.get_child_${cat_name_plural_under}(self.catalogs['Root'].ident)
-            assert isinstance(children, ABCObjects.${cat_name}List)
+            assert isinstance(children, OsidList)
             assert children.available() == 2
         else:
             with pytest.raises(errors.PermissionDenied):
@@ -2602,6 +2602,7 @@ def ${interface_name_under}_test_fixture(request):
 class BinNode:
 
     import_statements_pattern = [
+        'from dlkit.abstract_osid.cataloging.objects import Catalog'
     ]
 
     init_template = """
@@ -2668,7 +2669,10 @@ def ${interface_name_under}_test_fixture(request):
         # from test_templates/resource.py::BinNode::get_bin_template
         from dlkit.abstract_osid.${package_name_replace_reserved}.objects import ${cat_name}
         if not is_never_authz(self.service_config):
-            assert isinstance(self.${cat_name_under}_list[0].${method_name}(), ${cat_name})
+            if uses_cataloging(self.service_config):
+                assert isinstance(self.${cat_name_under}_list[0].${method_name}(), Catalog)
+            else:
+                assert isinstance(self.${cat_name_under}_list[0].${method_name}(), ${cat_name})
             assert str(self.${cat_name_under}_list[0].${method_name}().ident) == str(self.${cat_name_under}_list[0].ident)"""
 
     get_parent_bin_nodes_template = """

--- a/testbuilder.py
+++ b/testbuilder.py
@@ -57,6 +57,8 @@ class TestBuilder(InterfaceBuilder, BaseBuilder):
                 # i.e. Question.get_question_record() throws Unsupported()
                 impl = """        if is_never_authz(self.service_config):
             pass  # no object to call the method on?
+        elif uses_cataloging(self.service_config):
+            pass  # cannot call the _get_record() methods on catalogs
         else:
             with pytest.raises(errors.Unimplemented):
                 self.{0}.{1}({2})""".format(test_object,
@@ -104,7 +106,7 @@ class TestBuilder(InterfaceBuilder, BaseBuilder):
     def _update_module_imports(self, modules, interface):
         imports = modules[interface['category']]['imports']
         self.append(imports, 'import pytest')
-        self.append(imports, 'from ..utilities.general import is_never_authz, is_no_authz')
+        self.append(imports, 'from ..utilities.general import is_never_authz, is_no_authz, uses_cataloging')
 
         # Check to see if there are any additional inheritances required
         # by the implementation patterns.  THIS MAY WANT TO BE REDESIGNED


### PR DESCRIPTION
@birdland Can you please review this, specifically the changes to `osid/sessions` `OsidSession`'s `_init_object()` method? It seems kind of hacky, though I'm not sure what would be better to do.

The reason I added that code to `_init_object` is because I was running into an issue with the `AssetRepositorySession` test for `get_asset_ids_by_repository()`, where it was always returning `0`. I think because the `catalogId` value stored in the `Asset`'s `assignedRepositoryIds` had a namespace of `cataloging.Catalog`, but the method for `lookup_session.get_assets()` looked for `repository.Repository` (this also had the undesirable side-effect of creating an orchestrated `Repository` for each `Catalog`). So I needed to change `_init_object` to check for `cataloging` first.