### PR TITLE
Allow display text to be created from dictionaries

### DIFF
--- a/jsonosid_templates/osid.py
+++ b/jsonosid_templates/osid.py
@@ -1081,6 +1081,8 @@ class OsidForm:
                 'formatTypeId': str(inpt.format_type),
                 'scriptTypeId': str(inpt.script_type)
             }
+        elif isinstance(inpt, dict):
+            display_text = inpt
         elif self._is_valid_string(inpt, metadata):
             display_text = dict(metadata.get_default_string_values()[0])
             display_text.update({'text': inpt})


### PR DESCRIPTION
Allow `display_text` to be created from a dictionary. Thus, it can be created from a json piece like this:

    "displayName": {
      "formatTypeId": "format.text%3APlain%40okapia.net",
      "languageTypeId": "639-2%3AENG%40iso.org",
      "scriptTypeId": "15924%3ALATN%40iso.org",
      "text": "Default Gradebook"
    }, 